### PR TITLE
Do not constrain darwin linker flags to x86

### DIFF
--- a/crates/multihash/.cargo/config
+++ b/crates/multihash/.cargo/config
@@ -1,5 +1,4 @@
-[target.x86_64-apple-darwin]
+[target.'cfg(target_os="macos")']
 rustflags = [
-    "-C", "link-arg=-undefined",
-    "-C", "link-arg=dynamic_lookup",
+    "-C", "link-args=-undefined dynamic_lookup",
 ]


### PR DESCRIPTION
This patch allows us to target macOS on aarch64.